### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM mhart/alpine-node:14
 
 RUN mkdir /benchmarking
 
-RUN apk add git
-
-RUN git clone https://github.com/sine-fdn/benchmarking_ui /benchmarking
+COPY . /benchmarking
 
 WORKDIR /benchmarking
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mhart/alpine-node:14
+
+RUN mkdir /benchmarking
+
+RUN apk add git
+
+RUN git clone https://github.com/sine-fdn/benchmarking_ui /benchmarking
+
+WORKDIR /benchmarking
+
+RUN yarn install && yarn build
+
+CMD ["node",".next/production-server/index.js"]


### PR DESCRIPTION
Hello,
as a customer, it would be great if the images are hosted on a public repository (e.g. Docker Hub), so we can always pull the newest version without building it ourselves.

https://github.com/marketplace/actions/build-and-push-docker-images